### PR TITLE
Store segment_source name in state file

### DIFF
--- a/segment/resource_segment_source.go
+++ b/segment/resource_segment_source.go
@@ -58,6 +58,7 @@ func resourceSegmentSourceRead(r *schema.ResourceData, meta interface{}) error {
 	}
 
 	r.Set("catalog_name", s.CatalogName)
+	r.Set("source_name", srcName)
 
 	return nil
 }
@@ -85,6 +86,7 @@ func resourceSegmentSourceImport(r *schema.ResourceData, meta interface{}) ([]*s
 
 	r.SetId(s.Name)
 	r.Set("catalog_name", s.CatalogName)
+	r.Set("source_name", idToName(s.Name))
 
 	results := make([]*schema.ResourceData, 1)
 	results[0] = r


### PR DESCRIPTION
Otherwise, it causes a re-generation of resources for no reason (we don't have enough information to turn ID back to resource in the TF file).